### PR TITLE
Configurable settings - Linebreaks, fontsize, and font-family

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,5 @@
 const vscode = require("vscode");
 
-
 function activate(context) {
   let panel = null;
 
@@ -341,7 +340,6 @@ function updatePreview(fullText, panel) {
   let breakbetweenlines = config.get("breakbetweenlines");
   let fontfamily = config.get("displayfont");
   let fontsize = config.get("displayfontsize");
-  
 
   const lines = fullText.split("\n");
 
@@ -379,8 +377,7 @@ function updatePreview(fullText, panel) {
       }
     });
 
-    if( breakbetweenlines )
-      formattedText += `<br>`;
+    if (breakbetweenlines) formattedText += `<br>`;
   });
 
   panel.webview.html = `

--- a/extension.js
+++ b/extension.js
@@ -1,5 +1,6 @@
 const vscode = require("vscode");
 
+
 function activate(context) {
   let panel = null;
 
@@ -335,6 +336,13 @@ function updatePreview(fullText, panel) {
   let lastColorCode = null;
   let formattedText = "";
 
+  // fetch the configurations on update.
+  let config = vscode.workspace.getConfiguration("lotjcolor");
+  let breakbetweenlines = config.get("breakbetweenlines");
+  let fontfamily = config.get("displayfont");
+  let fontsize = config.get("displayfontsize");
+  
+
   const lines = fullText.split("\n");
 
   lines.forEach((line) => {
@@ -371,12 +379,13 @@ function updatePreview(fullText, panel) {
       }
     });
 
-    formattedText += `<br>`;
+    if( breakbetweenlines )
+      formattedText += `<br>`;
   });
 
   panel.webview.html = `
     <html>
-      <body style="font-family: 'Courier New', Courier, monospace; white-space: pre;">
+      <body style="font-size: ${fontsize}em; font-family: ${fontfamily}; white-space: pre;">
         ${formattedText}
       </body>
     </html>

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         },
         "lotjcolor.displayfontsize": {
           "type": "number",
-          "default": 1,
+          "default": 0.8125,
           "description": "Size of font in display, entered in points."
         }
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lotjcolor",
   "displayName": "LotJ Color",
   "description": "",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "publisher": "Mnemosyne",
   "engines": {
     "vscode": "^1.92.0"
@@ -22,7 +22,27 @@
         "command": "extension.lotjColor",
         "title": "LotJ Color Preview"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Lotj Color Preview",
+      "properties": {
+        "lotjcolor.breakbetweenlines": {
+          "type": "boolean",
+          "default": true,
+          "description": "Include a blank line-break between lines."
+        },
+        "lotjcolor.displayfont": {
+          "type": "string",
+          "default": "'Courier New', Courier, monospace",
+          "description": "Font-style to use, entered in css-format."
+        },
+        "lotjcolor.displayfontsize": {
+          "type": "number",
+          "default": 1,
+          "description": "Size of font in display, entered in points."
+        }
+      }
+    }
   },
   "scripts": {
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "lotjcolor.displayfontsize": {
           "type": "number",
           "default": 0.8125,
-          "description": "Size of font in display, entered in points."
+          "description": "Size of font in display, entered in em units."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lotjcolor",
   "displayName": "LotJ Color",
   "description": "",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "publisher": "Mnemosyne",
   "engines": {
     "vscode": "^1.92.0"


### PR DESCRIPTION
Extends the use-case of the tool in an easy way.
Example cases -

1. I am very dyslexic and run with a different font-size and font-family
2. This tool appeals to me for writing and storing multiple-line character descriptions, where the double-line-breaks greatly impacted visible judgements.

These configurations have been set to default values that should maintain existing behavior without any break. Please test and review that.